### PR TITLE
hotfix url routing and leaderboard linking

### DIFF
--- a/public_html/leaderboard.html
+++ b/public_html/leaderboard.html
@@ -34,7 +34,7 @@
       <br />
       <div class="row">
         <div class="col">
-          <a href="/" class="btn btn-primary">Back to game</a>
+          <a href="/index" class="btn btn-primary">Back to game</a>
         </div>
         <h1 class="header">Nim Leaderboards</h1>
       </div>

--- a/server.js
+++ b/server.js
@@ -33,6 +33,10 @@ function serverParse(req, res) {
 //Does url switching for static pages
 function handlePage(url, res) {
   switch (url.pathname.match('^(\/[^\/]*)')[1]) {
+    case "/leaderboard":
+      staticServe.leaderboard(url, res);
+      break;
+    
     //logically equivalent default pathnames fallthrough cases
     case "/signup":
     case "/":


### PR DESCRIPTION
re-added routing for leaderboard
re-linked leaderboard back to /index